### PR TITLE
Defer icon loading

### DIFF
--- a/src/BladeCssIconsServiceProvider.php
+++ b/src/BladeCssIconsServiceProvider.php
@@ -9,10 +9,12 @@ final class BladeCssIconsServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        $this->app->make(Factory::class)->add('css-icons', [
-            'path' => __DIR__ . '/../resources/svg',
-            'prefix' => 'css',
-        ]);
+        $this->callAfterResolving(Factory::class, function (Factory $factory) {
+            $factory->add('css-icons', [
+                'path' => __DIR__ . '/../resources/svg',
+                'prefix' => 'css',
+            ]);
+        });
 
         if ($this->app->runningInConsole()) {
             $this->publishes([


### PR DESCRIPTION
These changes will defer the icon loading until the factory has actually been resolved. This is also the new recommended way for packages to integrate with Blade Icons. No breaking changes, the previous way will still work.